### PR TITLE
Fix graceful shutdown

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,3 +24,5 @@ linters-settings:
   maligned:
     # print struct with more effective memory layout or not, false by default
     suggest-new: true
+  errcheck:
+    ignore: github.com/kucherenkovova/micron:^.*Stop.*

--- a/app.go
+++ b/app.go
@@ -209,7 +209,7 @@ func (a *App) setError(err error) {
 }
 
 func (a *App) setupGracefulShutdown(ctx context.Context) {
-	defer a.cancel()
+	defer a.Stop(ctx)
 
 	signaled := make(chan os.Signal, 1)
 	signal.Notify(signaled, syscall.SIGINT, syscall.SIGTERM)


### PR DESCRIPTION
Call `app.Stop(ctx)` after SIGTERM/SIGINT signals.